### PR TITLE
[WIP] Added nvcc to the list of toolsets to test.

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -22,6 +22,24 @@ else if [ os.name ] = MACOSX
   toolset-choices += darwin ;
 }
 
+# nvcc toolsets
+if [ os.name ] = NT
+{
+  toolset-choices += nvcc-9.2 ;
+}
+else if [ os.name ] = CYGWIN
+{
+  toolset-choices += nvcc-9.2 ;
+}
+else if [ os.name ] = LINUX
+{
+  toolset-choices += nvcc-9.1 ;
+}
+else if [ os.name ] = MACOSX
+{
+  toolset-choices += nvcc-9.2 ;
+}
+
 echo "building for the following toolsets:" ;
 for local t in $(toolset-choices)
 {
@@ -100,3 +118,11 @@ link main_a_cpp.cpp liba_cpp ;
 link stdlib_io_cpp.cpp ;
 link stdlib_cpp.cpp ;
 run hello_cpp.cpp ;
+
+#compile a_cu.cu : <toolset>nvcc ;
+#link main_cu.cu : <toolset>nvcc ;
+#lib liba_cu : a_cu.cu a_cu.cuh : <toolset>nvcc ;
+#link main_a_cu.cu liba_cu : <toolset>nvcc ;
+#link stdlib_io_cu.cu : <toolset>nvcc ;
+#link stdlib_cu.cu : <toolset>nvcc ;
+#run hello_cu.cu : <toolset>nvcc ;

--- a/README.rst
+++ b/README.rst
@@ -80,11 +80,28 @@ following command.
        link=static \
        threading=single
 
+To limit tests during development, narrow the properties as much as
+possible to test as few variants as desired.  For example, to minimize
+the GPU architecture and GPU code, run the following command.
+
+.. code:: sh
+
+   $ b2 --test-config=user-config.jam \
+       --hash \
+        toolset=nvcc \
+        gpu-architecture=compute_70 \
+        gpu-code=sm_70
+
 Requirements
 ------------
 
 * Boost.Build
 * All desired compilers
+
+NVIDIA nvcc
+~~~~~~~~~~~
+
+CUDA installed in the default location.
 
 Adding Toolsets
 ---------------

--- a/a_cu.cu
+++ b/a_cu.cu
@@ -1,0 +1,9 @@
+#include "a_cpp.cuh"
+
+namespace acpp
+{
+   void
+   acpp ()
+   {
+   }
+}

--- a/a_cu.cuh
+++ b/a_cu.cuh
@@ -1,0 +1,10 @@
+#ifndef acpp_hpp_
+#define acpp_hpp_
+
+namespace acpp
+{
+   void
+   acpp ();
+}
+
+#endif

--- a/hello_cu.cu
+++ b/hello_cu.cu
@@ -1,0 +1,9 @@
+#include <string>
+
+int
+main ()
+{
+   std::string s ("Hello, world!\n");
+
+   return 0;
+}

--- a/main_a_cu.cu
+++ b/main_a_cu.cu
@@ -1,0 +1,9 @@
+#include "a_cpp.cuh"
+
+int
+main ()
+{
+   acpp::acpp ();
+
+   return 0;
+}

--- a/main_cu.cu
+++ b/main_cu.cu
@@ -1,0 +1,5 @@
+int
+main ()
+{
+   return 0;
+}

--- a/project-config.jam
+++ b/project-config.jam
@@ -1,5 +1,17 @@
 import os ;
 
+path-constant boost-build-nvcc : ../boost-build-nvcc ;
+
+# @todo HACK - add tools to the Boost.Build path
+{
+  import modules ;
+
+  local boost-build-path = [ modules.peek : BOOST_BUILD_PATH ] ;
+  modules.poke : BOOST_BUILD_PATH : $(boost-build-nvcc) $(boost-build-path) ;
+}
+
+path-constant HOME : [ os.environ HOME ] ;
+
 # Default toolsets
 if [ os.name ] = NT
 {
@@ -17,3 +29,7 @@ else if [ os.name ] = MACOSX
 {
   using darwin ;
 }
+
+# NVIDIA toolsets
+
+using nvcc ;

--- a/stdlib_cu.cu
+++ b/stdlib_cu.cu
@@ -1,0 +1,9 @@
+#include <string>
+
+int
+main ()
+{
+   std::string s ("Hello, world!\n");
+
+   return 0;
+}

--- a/stdlib_io_cu.cu
+++ b/stdlib_io_cu.cu
@@ -1,0 +1,9 @@
+#include <iostream>
+
+int
+main ()
+{
+   std::cout << "Hello, world!\n";
+
+   return 0;
+}


### PR DESCRIPTION
This needs to be able to enable building `.cu` files only for `nvcc`.  Currently, it attempts to build them for other compilers as well.

This assumes that the nvcc toolset is in a directory named `../boost-build-nvcc`.
